### PR TITLE
Adding openjdk package dependency

### DIFF
--- a/bin/setup_base
+++ b/bin/setup_base
@@ -30,4 +30,4 @@ $retry curl -fsSL https://download.docker.com/linux/$distrib/gpg | sudo apt-key 
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$distrib $release stable"
 
 $AG update
-$AG install openvswitch-switch openvswitch-common docker-ce
+$AG install openvswitch-switch openvswitch-common docker-ce openjdk-8-jdk


### PR DESCRIPTION
The openjdk-8-jdk package is needed by the bin/mudacl program. I'm adding it to the setup_base script, but could be added to the setup_dev one if more appropriate