### PR TITLE
Added mudfile for bacnet controller

### DIFF
--- a/mud_files/bacnet_controller.json
+++ b/mud_files/bacnet_controller.json
@@ -1,0 +1,620 @@
+{
+  "ietf-mud:mud": {
+    "mud-version": 1,
+    "mud-url": "https://digital-building.org/mud/bacnet_controller",
+    "last-update": "2018-08-23T20:43:36+02:00",
+    "cache-validity": 48,
+    "is-supported": true,
+    "systeminfo": "Generic BACnet controller",
+    "from-device-policy": {
+      "access-lists": {
+        "access-list": [
+          {
+            "name": "mud-58064-v4fr"
+          }
+        ]
+      }
+    },
+    "to-device-policy": {
+      "access-lists": {
+        "access-list": [
+          {
+            "name": "mud-58064-v4to"
+          }
+        ]
+      }
+    }
+  },
+  "ietf-access-control-list:acls": {
+    "acl": [
+      {
+        "name": "mud-58064-v4to",
+        "type": "ipv4-acl-type",
+        "aces": {
+          "ace": [
+            {
+              "name": "ntp-todev",
+              "matches": {
+                "ipv4": {
+                  "ietf-acldns:src-dnsname": "pool.ntp.org",
+                  "protocol": 17
+                },
+		"udp": {
+                  "source-port": {
+                     "operator": "eq",
+                     "port": 123
+                   }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "smtp-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "from-device",
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 25
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 25
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dnstcp-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "from-device",
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 53
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 53
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dnsudp-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 53
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 53
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dhcp-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 67
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 67
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "http-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "from-device",
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 80
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 80
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "ntp-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 123
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 123
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "https-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "from-device",
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 443
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 443
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusauth-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1812
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1812
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusacc-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1813
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1813
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusproxy-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1814
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1814
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "bacnet-todev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 47808
+                  },
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 47808
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "mud-58064-v4fr",
+        "type": "ipv4-acl-type",
+        "aces": {
+          "ace": [
+            {
+              "name": "ntp-frdev",
+              "matches": {
+                "ipv4": {
+                  "ietf-acldns:dst-dnsname": "pool.ntp.org",
+                  "protocol": 17
+                },
+                "udp": {
+                  "source-port": {
+                     "operator": "eq",
+                     "port": 123
+                   }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "smtp-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+		  "ietf-mud:direction-initiated": "to-device",
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 25
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 25
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dnstcp-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "from-device",
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 53
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 53
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dnsudp-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 53
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 53
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "dhcp-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 67
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 67
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "http-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "to-device",
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 80
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 80
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "ntp-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 123
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 123
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "https-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 6
+                },
+                "tcp": {
+                  "ietf-mud:direction-initiated": "to-device",
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 443
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 443
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusauth-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1812
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1812
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusacc-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1813
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1813
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "radiusproxy-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 1814
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 1814
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            },
+            {
+              "name": "bacnet-frdev",
+              "matches": {
+                "ietf-mud:mud": {
+                  "controller": "remote-host"
+                },
+                "ipv4": {
+                  "protocol": 17
+                },
+                "udp": {
+                  "destination-port": {
+                    "operator": "eq",
+                    "port": 47808
+                  },
+                  "source-port": {
+                    "operator": "eq",
+                    "port": 47808
+                  }
+                }
+              },
+              "actions": {
+                "forwarding": "accept"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
I've created a MUD file for a generic BACnet controller that generates ACL files using mudacl.
There are still a lot of open ports (for Radius services for instance) so I can simplify further.