### PR TITLE
Add netmask

### DIFF
--- a/bin/physical_sec
+++ b/bin/physical_sec
@@ -50,7 +50,7 @@ if ! ifconfig $ext_ctrl || ! ifconfig $ext_intf; then
 fi
 
 sudo ip addr flush dev $ext_ctrl
-sudo ip addr add $ext_ofip dev $ext_ctrl
+sudo ip addr add $ext_ofip/16 dev $ext_ctrl
 
 sudo ip link set up dev $ext_ctrl
 


### PR DESCRIPTION
While testing this scripts with the Zodiac FX on Debian GNU/linux, I had a consistent behaviour that was putting the data plane IP address with a 255.255.255.255 netmask. This was making the physical_sec script fail.
I solved the issue by adding the /16 netmask.
I'm not sure if this the correct way of solving this issue, but thought of creating a pull request so I can have some comments.