### PR TITLE
Default to build-all for docker

### DIFF
--- a/cmd/build
+++ b/cmd/build
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 # The following are expected modes of builds
-# cmd/build <- Pull images referenced, then builds the ones that are missing 
+# cmd/build <- defaults to build-all
+# cmd/build check <- Pull images referenced, then builds the ones that are missing
 # cmd/build push <- Pushes images referenced in DOCKER_IMAGES_LIST to docker hub
 # cmd/build pull <- Pulls images referenced in DOCKER_IMAGES_LIST to docker hub
 # cmd/build build-all <- Builds all docker images 
@@ -13,7 +14,7 @@ ROOT=$(dirname $0)/..
 inline=
 copydirs="bin cmd misc faucet mininet docker daq subset"
 DOCKER_IMAGE_LIST=misc/docker_images.txt
-check_existing="check-existing"
+check_existing=
 
 cd $ROOT
 source misc/config_base.sh
@@ -53,6 +54,9 @@ elif [ "$1" == pull ]; then
     mv -f .build_files .build_built
     echo Done with docker build pull.
     exit 0
+elif [ "$1" == check ]; then
+    check_existing=check-existing
+    shift
 elif [ "$1" == build-all ]; then
     check_existing=""
     shift

--- a/cmd/run
+++ b/cmd/run
@@ -16,7 +16,7 @@ sudo rm -rf inst/reports inst/run-port-* $cmdrun_log
 sudo chown -f $USER -R inst || true
 
 if [ -n "$build_tests" ]; then
-    cmd/build pull
+    cmd/build
 fi
 
 bin/build_hash check

--- a/docker/Dockerfile.faux
+++ b/docker/Dockerfile.faux
@@ -71,6 +71,4 @@ COPY misc/start_faux misc/failing bin/
 # Weird workaround for problem running tcdump in a privlidged container.
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
-THIS SHOULD BREAK BUT IT DOESNT
-
 ENTRYPOINT ["bin/start_faux"]

--- a/docker/Dockerfile.faux
+++ b/docker/Dockerfile.faux
@@ -71,4 +71,6 @@ COPY misc/start_faux misc/failing bin/
 # Weird workaround for problem running tcdump in a privlidged container.
 RUN mv /usr/sbin/tcpdump /usr/bin/tcpdump
 
+THIS SHOULD BREAK BUT IT DOESNT
+
 ENTRYPOINT ["bin/start_faux"]

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -167,6 +167,7 @@ port-02 module_config modules
                 ')
 Redacted docs diff
 No report diff
+ M misc/docker_images.txt
 01: ['01:ping:Exception']
 02: ['02:ping:ValueError']
 03: ['03:ping:Exception']


### PR DESCRIPTION
I don't think we can enable docker pull by default -- there's too many problem and inconsistencies that will confuse external developers, e.g. https://github.com/grafnu/daq/commit/cfb0e6ca1adb6e92431a4e7796bcf6e22f376749