### PR TITLE
Increase notes column in report test

### DIFF
--- a/daq/report.py
+++ b/daq/report.py
@@ -176,7 +176,7 @@ class ReportGenerator:
         LOGGER.info('Generating HTML for writing pdf report...')
         pypandoc.convert_file(self.path, 'html',
                               outputfile=self._REPORT_TMP_HTML_PATH,
-                              extra_args=['-V', 'geometry:margin=1.5cm','--columns','1000'])
+                              extra_args=['-V', 'geometry:margin=1.5cm', '--columns', '1000'])
         LOGGER.info('Metamorphosising HTML to PDF...')
         weasyprint.HTML(self._REPORT_TMP_HTML_PATH) \
             .write_pdf(self.path_pdf, stylesheets=[weasyprint.CSS(self._REPORT_CSS_PATH)])

--- a/daq/report.py
+++ b/daq/report.py
@@ -176,7 +176,7 @@ class ReportGenerator:
         LOGGER.info('Generating HTML for writing pdf report...')
         pypandoc.convert_file(self.path, 'html',
                               outputfile=self._REPORT_TMP_HTML_PATH,
-                              extra_args=['-V', 'geometry:margin=1.5cm'])
+                              extra_args=['-V', 'geometry:margin=1.5cm','--columns','1000'])
         LOGGER.info('Metamorphosising HTML to PDF...')
         weasyprint.HTML(self._REPORT_TMP_HTML_PATH) \
             .write_pdf(self.path_pdf, stylesheets=[weasyprint.CSS(self._REPORT_CSS_PATH)])


### PR DESCRIPTION
#313 
Number of columns set to 1000 in to prevent pandoc assigning widths in the HTML precursor to the PDF reports thus allows the full width of the page to be used. If information to the left of the notes column (e.g. test names) increase, font sizes may additionally need to be reduced or other formatting change.

https://pandoc.org/MANUAL.html#tables 