### PR TITLE
Use update method signature for gcp credentials

### DIFF
--- a/daq/gcp.py
+++ b/daq/gcp.py
@@ -58,7 +58,7 @@ class GcpManager:
         LOGGER.info('Loading gcp credentials from %s', cred_file)
         # Normal execution assumes default credentials.
         # pylint: disable=protected-access
-        (self._credentials, self._project) = google_auth._load_credentials_from_file(cred_file)
+        (self._credentials, self._project) = google_auth.load_credentials_from_file(cred_file)
         self._client_name = self._parse_creds(cred_file)
         self._site_name = self._get_site_name()
         self._pubber = pubsub_v1.PublisherClient(credentials=self._credentials)

--- a/daq/gcp.py
+++ b/daq/gcp.py
@@ -57,7 +57,6 @@ class GcpManager:
             return
         LOGGER.info('Loading gcp credentials from %s', cred_file)
         # Normal execution assumes default credentials.
-        # pylint: disable=protected-access
         (self._credentials, self._project) = google_auth.load_credentials_from_file(cred_file)
         self._client_name = self._parse_creds(cred_file)
         self._site_name = self._get_site_name()


### PR DESCRIPTION
Some library changed somewhere, and the ugly "use a private method" hack is no longer necessary (nor possible)... but now we get to use the proper public function!
