### PR TITLE
granular dhcp test timeouts.

### DIFF
--- a/config/modules/host.conf
+++ b/config/modules/host.conf
@@ -4,9 +4,9 @@
 build docker/modules
 
 # Default built-in tests.
-add pass
-add fail
-add ping
+add pass first
+add fail first
+add ping first
 add bacnet
 add mudgee
 

--- a/daq/host.py
+++ b/daq/host.py
@@ -383,6 +383,8 @@ class ConnectedHost:
     def heartbeat(self):
         """Checks module run time for each event loop"""
         timeout_sec = self._get_test_timeout(self.test_name)
+        if self.test_host:
+            self.test_host.heartbeat()
         if not timeout_sec or not self.test_start:
             return
         timeout = gcp.parse_timestamp(self.test_start) + timedelta(seconds=timeout_sec)

--- a/daq/runner.py
+++ b/daq/runner.py
@@ -164,7 +164,7 @@ class DAQRunner:
         if logging_client:
             logger.set_stackdriver_client(logging_client,
                                           labels={"daq_run_id": self.daq_run_id})
-        test_list = self._get_test_list(config.get('host_tests', self._DEFAULT_TESTS_FILE), [])
+        test_list = self._get_test_list(config.get('host_tests', self._DEFAULT_TESTS_FILE))
         if self.config.get('keep_hold'):
             LOGGER.info('Appending test_hold to master test list')
             test_list.append('hold')
@@ -502,41 +502,45 @@ class DAQRunner:
         except Exception as e:
             self.target_set_error(device, e)
 
-    def _get_test_list(self, test_file, test_list, pointer=0):
+    def _get_test_list(self, test_file):
         no_test = self.config.get('no_test', False)
         if no_test:
             LOGGER.warning('Suppressing configured tests because no_test')
-            return test_list
-        LOGGER.info('Reading test definition file %s', test_file)
-        with open(test_file) as file:
-            line = file.readline()
-            while line:
-                cmd = re.sub(r'#.*', '', line).strip().split()
-                cmd_name = cmd[0] if cmd else None
-                argument = cmd[1] if len(cmd) > 1 else None
-                ordering = cmd[2] if len(cmd) > 2 else None
-                if cmd_name == 'add':
-                    LOGGER.debug('Adding test %s from %s', argument, test_file)
-                    if ordering == "first":
-                        test_list.prepend(argument)
-                        pointer += 1
-                    elif ordering == "last":
-                        test_list.append(argument)
-                    else:
-                        test_list.insert(pointer, argument)
-                        pointer += 1
-                elif cmd_name == 'remove':
-                    if argument in test_list:
-                        LOGGER.debug('Removing test %s from %s', argument, test_file)
-                        test_list.remove(argument)
-                elif cmd_name == 'include':
-                    self._get_test_list(argument, test_list, pointer=pointer)
-                elif cmd_name == 'build' or not cmd_name:
-                    pass
-                else:
-                    LOGGER.warning('Unknown test list command %s', cmd_name)
+            return []
+        head = []
+        body = []
+        tail = []
+        def get_test_list(test_file):
+            LOGGER.info('Reading test definition file %s', test_file)
+            with open(test_file) as file:
                 line = file.readline()
-        return test_list
+                while line:
+                    cmd = re.sub(r'#.*', '', line).strip().split()
+                    cmd_name = cmd[0] if cmd else None
+                    argument = cmd[1] if len(cmd) > 1 else None
+                    ordering = cmd[2] if len(cmd) > 2 else None
+                    if cmd_name == 'add':
+                        LOGGER.debug('Adding test %s from %s', argument, test_file)
+                        if ordering == "first":
+                            head.append(argument)
+                        elif ordering == "last":
+                            tail.append(argument)
+                        else:
+                            body.append(argument)
+                    elif cmd_name == 'remove':
+                        LOGGER.debug('Removing test %s from %s', argument, test_file)
+                        for section in (head, body, tail):
+                            if argument in section:
+                                section.remove(argument)
+                    elif cmd_name == 'include':
+                        get_test_list(argument)
+                    elif cmd_name == 'build' or not cmd_name:
+                        pass
+                    else:
+                        LOGGER.warning('Unknown test list command %s', cmd_name)
+                    line = file.readline()
+        get_test_list(test_file)
+        return [*head, *body, *tail]
 
     def _get_test_metadata(self, extension=".daqmodule", root="."):
         metadata = {}

--- a/daq/runner.py
+++ b/daq/runner.py
@@ -510,6 +510,7 @@ class DAQRunner:
         head = []
         body = []
         tail = []
+
         def get_test_list(test_file):
             LOGGER.info('Reading test definition file %s', test_file)
             with open(test_file) as file:

--- a/daq/test_modules/base_module.py
+++ b/daq/test_modules/base_module.py
@@ -42,5 +42,8 @@ class HostModule(ABC):
     def ip_listener(self, target_ip):
         """Defaults to do nothing about ip notifications"""
 
+    def heartbeat(self):
+        """For modules that need to do periodic checks"""
+
     def __repr__(self):
         return "Target device %s test %s" % (self.device, self.test_name)

--- a/resources/setups/baseline/module_config.json
+++ b/resources/setups/baseline/module_config.json
@@ -2,7 +2,7 @@
   "modules": {
     "ipaddr": {
       "enabled": false,
-      "timeout_sec": 900,
+      "timeout_sec": 0,
       "port_flap_timeout_sec": 20,
       "dhcp_ranges": [{"start": "192.168.0.1", "end": "192.168.255.254", "prefix_length": 16}]
     },

--- a/subset/ipaddr/build.conf
+++ b/subset/ipaddr/build.conf
@@ -1,2 +1,2 @@
 build subset/ipaddr
-add ipaddr
+add ipaddr last

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -114,7 +114,7 @@ port-01 module_config modules
     ],
     "enabled": false,
     "port_flap_timeout_sec": 20,
-    "timeout_sec": 900
+    "timeout_sec": 0
   },
   "manual": {
     "enabled": true
@@ -173,7 +173,7 @@ port-02 module_config modules
     ],
     "enabled": false,
     "port_flap_timeout_sec": 20,
-    "timeout_sec": 900
+    "timeout_sec": 0
   },
   "manual": {
     "enabled": true

--- a/testing/test_dhcp.out
+++ b/testing/test_dhcp.out
@@ -5,6 +5,7 @@ DHCP Tests
 9a02571e8f03: []
 9a02571e8f04: []
 9a02571e8f05: []
+9a02571e8f06: ['9a02571e8f06:ipaddr:TimeoutError']
 Device 1 ip triggers: 1 0
 Device 2 ip triggers: 0 0
 Device 3 long ip triggers: 1


### PR DESCRIPTION
 Adding ability to specify relative test module ordering, so ipaddr always happen last.