### PR TITLE
New new ip assignment

### DIFF
--- a/config/system/default.yaml
+++ b/config/system/default.yaml
@@ -46,4 +46,4 @@ run_trigger_type: PORT
 # usi url for DAQ to connect to
 usi_setup: 
   url: localhost:5000
-  rpc_timeout_sec: 10
+  rpc_timeout_sec: 20

--- a/daq/host.py
+++ b/daq/host.py
@@ -68,7 +68,7 @@ class ConnectedHost:
     """Class managing a device-under-test"""
 
     _STARTUP_MIN_TIME_SEC = 5
-    _RPC_TIMEOUT_SEC = 10
+    _RPC_TIMEOUT_SEC = 20
     _INST_DIR = "inst/"
     _DEVICE_PATH = "device/%s"
     _NETWORK_DIR = "inst/network"

--- a/docker/include/network/scripts/change_dhcp_range
+++ b/docker/include/network/scripts/change_dhcp_range
@@ -14,6 +14,7 @@ fi
 while [ $(cat /etc/dnsmasq.conf | egrep "^dhcp-range=" | wc -l) == 0 ]; do 
     sleep 1
 done
+ip addr flush dev eth0 # Remove eth0 ip addr so there're no ip conflicts.
 ip addr add $range_start/$prefix_len dev $LOCAL_IF || true
 original=$(cat /etc/dnsmasq.conf | egrep "^dhcp-range=" | head -1)
 lease=$(echo $original | cut -d',' -f 3)

--- a/docker/include/network/scripts/new_ip
+++ b/docker/include/network/scripts/new_ip
@@ -10,11 +10,16 @@ fi
 
 function get_next_ip() {
     cur_ip=$1
-    prefix=$(echo $cur_ip | cut -d '.' -f 1,2)
-    subnet=$(echo $cur_ip | cut -d '.' -f 3)
-    new_subnet=$((($subnet + 1) % 256))
+    prefix=$(echo $cur_ip | cut -d '.' -f 1,2,3)
     postfix=$(echo $cur_ip | cut -d '.' -f 4)
-    new_ip=$prefix.$new_subnet.$postfix
+    new_postfix=$((($postfix + 1) % 256))
+    while [ $(grep $prefix.$new_postfix /var/lib/misc/dnsmasq.leases | wc -l) -gt 0 ]; do
+        if [ $new_postfix -eq $postfix ]; then
+            break
+        fi
+        new_postfix=$((($new_postfix + 1) % 256))
+    done
+    new_ip=$prefix.$new_postfix
 }
 
 original=$(cat /etc/dnsmasq.conf | egrep "dhcp-host=$mac_addr,([0-9]{1,3}\.){3}[0-9]{1,3}" | head -1)

--- a/subset/switches/test_switch
+++ b/subset/switches/test_switch
@@ -26,7 +26,9 @@ if [ -n "$LOCAL_IP" ]; then
     echo Switch test with model $SWITCH_MODEL
     echo Switch test with ip:port $SWITCH_IP:$TARGET_PORT
     echo Switch test with username:password $SWITCH_USERNAME:$SWITCH_PASSWORD
-    ping -n -c 10 $SWITCH_IP
+
+    # It may take up to 40 pings for it to go through for Cisco switch. Root cause is still unknown atm.
+    ping -n -c 100 $SWITCH_IP
     POE_ENABLED=`jq -r .modules.switch.poe.enabled $MODULE_CONFIG`
     java -jar switches/target/switchtest-0.0.1-jar-with-dependencies.jar $USI_URL $RPC_TIMEOUT $SWITCH_IP $TARGET_PORT $POE_ENABLED $SWITCH_MODEL $SWITCH_USERNAME $SWITCH_PASSWORD
 

--- a/testing/test_dhcp.out
+++ b/testing/test_dhcp.out
@@ -10,7 +10,7 @@ Device 1 ip triggers: 1 0
 Device 2 ip triggers: 0 0
 Device 3 long ip triggers: 1
 Device 4 ip triggers: 1
-Device 4 subnet 1 ip: 1 subnet 2 ip: 1 subnet 3 ip: 2
+Device 4 subnet 1 ip: 1 subnet 2 ip: 1 subnet 3 ip: 2 ip_changed: 1
 Device 5 ip triggers: 1
 Device 5 num of ips: 2
 DHCP timeouts: 1

--- a/testing/test_dhcp.sh
+++ b/testing/test_dhcp.sh
@@ -108,7 +108,8 @@ for iface in $(seq 1 5); do
       subnet_ip=$(fgrep "ip notification 192.168" inst/run-*/nodes/ipaddr*/tmp/activate.log | wc -l)
       subnet2_ip=$(fgrep "ip notification 10.255.255" inst/run-*/nodes/ipaddr*/tmp/activate.log | wc -l)
       subnet3_ip=$(fgrep "ip notification 172.16.0" inst/run-*/nodes/ipaddr*/tmp/activate.log | wc -l)
-      echo "Device $iface subnet 1 ip: $subnet_ip subnet 2 ip: $subnet2_ip subnet 3 ip: $subnet3_ip" | tee -a $TEST_RESULTS
+      subnet_ip_change=$(fgrep "ip notification 172.16.0" inst/run-*/nodes/ipaddr*/tmp/activate.log | awk '{print $6}' | uniq | wc -l)
+      echo "Device $iface subnet 1 ip: $subnet_ip subnet 2 ip: $subnet2_ip subnet 3 ip: $subnet3_ip ip_changed: $((subnet_ip_change > 1))" | tee -a $TEST_RESULTS
     elif [ $iface == 3 ]; then
       echo "Device $iface long ip triggers: $((long_triggers > 0))" | tee -a $TEST_RESULTS
     else


### PR DESCRIPTION
Also includes the extension of rpc_timeout_sec and ping counts for Cisco switches. 
The new new ip script assigns a new ip from the same /24 prefix to avoid issues with dnsmasq. 
