### PR TITLE
fix base.target.ping always passing

### DIFF
--- a/subset/ping/test_ping
+++ b/subset/ping/test_ping
@@ -68,7 +68,7 @@ fi
 # First ping might fail b/c of warm-up delays.
 summary=""
 local_status=pass
-ping -n -c 10 $TARGET_IP || (local_status=fail && status=fail)
+ping -n -c 10 $TARGET_IP || local_status=fail && status=fail
 
 if [ $local_status == pass ]; then
     summary="target reached"


### PR DESCRIPTION
The base.target.ping test seems to always pass even when a device is unreachable or drops ping requests. This PR makes a small syntax changes and it now it fails base.target.ping under these scenarios