### PR TITLE
Use installed python version as default python

### DIFF
--- a/bin/setup_daq
+++ b/bin/setup_daq
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+uname -a
+lsb_release -a
+
 ROOT=$(dirname $0)/..
 cd $ROOT
 

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -58,6 +58,11 @@ $AG install \
     python$PVERSION python3-pkg-resources python3-setuptools \
     python$PVERSION-dev python3-pip python emacs-nox python$PVERSION-venv nmap
 
+readlink -f $(which python)
+PYTHON_BIN=$(readlink -f $(which python))
+echo Python binary is at $PYTHON_BIN
+sudo ls -fs $PYTHON_BIN /usr/bin/python
+
 if [ -d mininet ]; then
     echo Checking mininet version matches $MININETV...
     targetrev=$(cd mininet; git rev-parse $MININETV)

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -58,10 +58,10 @@ $AG install \
     python$PVERSION python3-pkg-resources python3-setuptools \
     python$PVERSION-dev python3-pip python emacs-nox python$PVERSION-venv nmap
 
-readlink -f $(which python)
 PYTHON_BIN=$(readlink -f $(which python))
 echo Python binary is at $PYTHON_BIN
-sudo ls -fs $PYTHON_BIN /usr/bin/python
+sudo ln -fs $PYTHON_BIN /usr/bin/python
+ls -l /usr/bin/python
 
 if [ -d mininet ]; then
     echo Checking mininet version matches $MININETV...

--- a/bin/setup_dev
+++ b/bin/setup_dev
@@ -60,8 +60,6 @@ $AG install \
 
 PYTHON_BIN=$(readlink -f $(which python))
 echo Python binary is at $PYTHON_BIN
-sudo ln -fs $PYTHON_BIN /usr/bin/python
-ls -l /usr/bin/python
 
 if [ -d mininet ]; then
     echo Checking mininet version matches $MININETV...
@@ -85,6 +83,8 @@ else
             perl -pi -e "s/${i}//g" util/install.sh ;
         done
         sed -i s/cgroup-bin/cgroup-tools/ util/install.sh
+        export PYTHON_BIN
+        sed -i 's/sudo PYTHON=${PYTHON} make install/sudo PYTHON=${PYTHON_BIN} make install/' util/install.sh
         util/install.sh -n
     )
     touch mininet/.the_house_that_daq_built


### PR DESCRIPTION
It seems that Mininet has been compiled with Python 2 instead of Python 3. What happened is that Python3 is installed as `/opt/hostedtoolcache/Python/3.8.8/x64/bin/python`. When python3 is installed, the target of `/usr/bin/python` is not updated accordingly and still points to python2.7.  And when compiling mininet, the script runs python with sudo. As `/opt/hostedtoolcache/...` is not included in the root user's PATH, it will use `/usr/bin/python`, i.e., python2, as the interpreter.

I found this because there is an issue in my own repo's github action: the mininet compilation failed because the mininet installation script installs setuptools in python3 but uses python2 for compiling. 

https://github.com/didovesei/daq/runs/2243711116?check_suite_focus=true

Seems that the complilation failure arises only in github action image 20210330.1, while faucetsdn's image is not updated yet.