### PR TITLE
Use varz_port_2 in DAQ config for Gauge varz port

### DIFF
--- a/cmd/faucet
+++ b/cmd/faucet
@@ -30,10 +30,10 @@ fi
 
 if [ "$1" == "gauge" ]; then
     BASECMD=gauge
-    PROM_TARGET=9303
+    PROM_TARGET=${switch_setup_varz_port_2:-9303}
     FAUCET_SOCK=
     ext_ofpt=${switch_setup_lo_port_2:-6654}
-    prom_pt=${switch_setup_varz_port_2:-9303}
+    prom_pt=$PROM_TARGET
     shift
 else
     BASECMD=faucet

--- a/daq/topology.py
+++ b/daq/topology.py
@@ -338,7 +338,7 @@ class FaucetTopology:
         """Return Gauge config"""
         config = {
             'dbs': {
-                'prometheus': {'prometheus_port': _gauge_varz_port, 'type': 'prometheus'}
+                'prometheus': {'prometheus_port': self._gauge_varz_port, 'type': 'prometheus'}
             },
             'faucet_configs': ['/etc/faucet/faucet.yaml'],
             'watchers': {

--- a/daq/topology.py
+++ b/daq/topology.py
@@ -59,7 +59,7 @@ class FaucetTopology:
         self.ext_intf = switch_setup.get('data_intf')
         self._native_faucet = switch_setup.get('native')
         self._ext_faucet = switch_setup.get('model') == self._EXT_STACK
-        self._gauge_varz_port = switch_setup.get('varz_port_2', self._DEFAULT_GAUGE_VARZ_PORT)
+        self._gauge_varz_port = int(switch_setup.get('varz_port_2', self._DEFAULT_GAUGE_VARZ_PORT))
         self._device_specs = self._load_device_specs()
         self._port_targets = {}
         self._set_devices = {}

--- a/daq/topology.py
+++ b/daq/topology.py
@@ -45,6 +45,7 @@ class FaucetTopology:
     _EXT_STACK = 'EXT_STACK'
     _OFPP_IN_PORT = 0xfffffff8
     _DOT1X_ETH_TYPE = 0x888e
+    _DEFAULT_GAUGE_VARZ_PORT = 9303
 
     def __init__(self, config):
         self.config = config
@@ -58,6 +59,7 @@ class FaucetTopology:
         self.ext_intf = switch_setup.get('data_intf')
         self._native_faucet = switch_setup.get('native')
         self._ext_faucet = switch_setup.get('model') == self._EXT_STACK
+        self._gauge_varz_port = switch_setup.get('varz_port_2', self._DEFAULT_GAUGE_VARZ_PORT)
         self._device_specs = self._load_device_specs()
         self._port_targets = {}
         self._set_devices = {}
@@ -336,7 +338,7 @@ class FaucetTopology:
         """Return Gauge config"""
         config = {
             'dbs': {
-                'prometheus': {'prometheus_port': 9303, 'type': 'prometheus'}
+                'prometheus': {'prometheus_port': _gauge_varz_port, 'type': 'prometheus'}
             },
             'faucet_configs': ['/etc/faucet/faucet.yaml'],
             'watchers': {

--- a/daq/varz_state_collector.py
+++ b/daq/varz_state_collector.py
@@ -68,9 +68,9 @@ def parse_args(raw_args):
     parser = argparse.ArgumentParser(description='Varz collector')
     parser.add_argument('-a', '--address', type=str, default=DEFAULT_VARZ_ADDRESS,
                         help='Varz endpoint address')
-    parser.add_argument('-f', '--faucet-varz-port', type=str, default=DEFAULT_FAUCET_VARZ_PORT,
+    parser.add_argument('-f', '--faucet-varz-port', type=int, default=DEFAULT_FAUCET_VARZ_PORT,
                         help='Faucet varz port')
-    parser.add_argument('-g', '--gauge-varz-port', type=str, default=DEFAULT_GAUGE_VARZ_PORT,
+    parser.add_argument('-g', '--gauge-varz-port', type=int, default=DEFAULT_GAUGE_VARZ_PORT,
                         help='Gauge varz port')
     parser.add_argument('-l', '--label-matches', type=str,
                         help='Only output samples whose labels match specified key value pairs')


### PR DESCRIPTION
Gauge has a different way to configure the Varz port from the Faucet's one: the port has to be configured in gauge.yaml not by the env variable. Making a change to set both the docker mapped port and the target port to varz_port_2 (if configured).