### PR TITLE
Fix TLS test bug and re-enable in CI

### DIFF
--- a/docs/device_report.md
+++ b/docs/device_report.md
@@ -52,7 +52,7 @@ Overall device result FAIL
 |---|---|---|---|---|---|---|---|---|
 |Base|2|FAIL|1/0/1|0/0/0|0/0/0|0/0/0|0/0/0|0/0/0|
 |Connection|12|FAIL|3/5/4|0/0/0|0/0/0|0/0/0|0/0/0|0/0/0|
-|Security|13|FAIL|2/4/4|0/0/0|0/0/1|0/0/0|0/2/0|0/0/0|
+|Security|13|FAIL|2/1/7|0/0/0|0/0/1|0/0/0|0/0/2|0/0/0|
 |NTP|2|PASS|2/0/0|0/0/0|0/0/0|0/0/0|0/0/0|0/0/0|
 |DNS|1|SKIP|0/0/1|0/0/0|0/0/0|0/0/0|0/0/0|0/0/0|
 |Communication|2|PASS|2/0/0|0/0/0|0/0/0|0/0/0|0/0/0|0/0/0|
@@ -64,11 +64,11 @@ Syntax: Pass / Fail / Skip
 
 |Expectation|pass|fail|skip|gone|
 |---|---|---|---|---|
-|Required Pass|10|1|10|8|
+|Required Pass|10|1|13|5|
 |Required Pass for PoE Devices|0|0|1|0|
 |Required Pass for BACnet Devices|0|1|2|0|
 |Required Pass for IoT Devices|0|0|1|0|
-|Recommended Pass|0|0|0|2|
+|Recommended Pass|0|0|2|0|
 |Other|1|0|4|2|
 
 |Result|Test|Category|Expectation|Notes|
@@ -109,11 +109,11 @@ Syntax: Pass / Fail / Skip
 |skip|security.password.ssh|Security|Required Pass|Port 22 not open on target device.|
 |skip|security.password.telnet|Security|Required Pass|Port 23 not open on target device.|
 |gone|security.ssh.version|Security|Required Pass||
-|gone|security.tls.v1_2_client|Security|Required Pass||
-|gone|security.tls.v1_2_server|Security|Required Pass||
-|gone|security.tls.v1_3_client|Security|Recommended Pass||
-|gone|security.tls.v1_3_server|Security|Recommended Pass||
-|gone|security.tls.v1_server|Security|Required Pass||
+|skip|security.tls.v1_2_client|Security|Required Pass|No client initiated TLS communication detected|
+|skip|security.tls.v1_2_server|Security|Required Pass|IOException unable to connect to server.|
+|skip|security.tls.v1_3_client|Security|Recommended Pass|No client initiated TLS communication detected|
+|skip|security.tls.v1_3_server|Security|Recommended Pass|IOException unable to connect to server.|
+|skip|security.tls.v1_server|Security|Required Pass|IOException unable to connect to server.|
 |gone|unknown.fake.llama|Other|Other||
 |gone|unknown.fake.monkey|Other|Other||
 
@@ -335,6 +335,90 @@ RESULT fail protocol.bacext.pic PICS file defined however a BACnet device was no
 |Attribute|Value|
 |---|---|
 |enabled|True|
+
+## Module tls
+
+
+#### Report
+
+```
+--------------------
+Collecting TLS cert from target address
+
+Gathering TLS 1 Server Information....
+TLS 1Server Implementation Skipping Test, could not open connection
+TLS 1 Server Information Complete.
+
+
+Gathering TLS 1.2 Server Information....
+TLS 1.2Server Implementation Skipping Test, could not open connection
+TLS 1.2 Server Information Complete.
+
+
+Gathering TLS 1.3 Server Information....
+TLS 1.3Server Implementation Skipping Test, could not open connection
+TLS 1.3 Server Information Complete.
+
+
+Gathering TLS Client X.X.X.X Information....
+TLS Client Information Complete.
+Gathering TLS Client X.X.X.X Information....
+TLS Client Information Complete.
+
+--------------------
+security.tls.v1_2_client
+--------------------
+Verify the device supports at least TLS 1.2 (as a client)
+--------------------
+See log above
+--------------------
+RESULT skip security.tls.v1_2_client No client initiated TLS communication detected
+
+--------------------
+security.tls.v1_2_server
+--------------------
+Verify the device supports TLS 1.2 (as a server)
+--------------------
+See log above
+--------------------
+RESULT skip security.tls.v1_2_server IOException unable to connect to server.
+
+--------------------
+security.tls.v1_3_client
+--------------------
+Verify the device supports at least TLS 1.3 (as a client)
+--------------------
+See log above
+--------------------
+RESULT skip security.tls.v1_3_client No client initiated TLS communication detected
+
+--------------------
+security.tls.v1_3_server
+--------------------
+Verify the device supports TLS 1.3 (as a server)
+--------------------
+See log above
+--------------------
+RESULT skip security.tls.v1_3_server IOException unable to connect to server.
+
+--------------------
+security.tls.v1_server
+--------------------
+Verify the device supports at least TLS 1.0 (as a server)
+--------------------
+See log above
+--------------------
+RESULT skip security.tls.v1_server IOException unable to connect to server.
+
+```
+
+#### Module Config
+
+|Attribute|Value|
+|---|---|
+|enabled|True|
+|timeout_sec|0|
+|ca_file|CA_Faux.pem|
 
 ## Module password
 

--- a/resources/setups/common/base_config.json
+++ b/resources/setups/common/base_config.json
@@ -65,7 +65,7 @@
       }
     },
     "tls": {
-      "enabled": false,
+      "enabled": true,
       "timeout_sec": 0
     },
     "hold": {

--- a/subset/security/Dockerfile.test_tls
+++ b/subset/security/Dockerfile.test_tls
@@ -8,6 +8,8 @@ RUN $AG update && $AG install openjdk-11-jdk git tshark
 
 COPY subset/security/ .
 
+RUN sh enable_tls1.sh
+
 RUN cd tlstest && ./gradlew build
 
 CMD ["./test_tls"]

--- a/subset/security/build.conf
+++ b/subset/security/build.conf
@@ -1,5 +1,4 @@
 build subset/security
-# TODO: Enable TLS once tests are fixed
-# add tls
+add tls
 add password
 add ssh

--- a/subset/security/enable_tls1.sh
+++ b/subset/security/enable_tls1.sh
@@ -1,0 +1,16 @@
+#!/bin/bash 
+#
+
+sed -i '1s/^/openssl_conf = default_conf;\n/' /etc/ssl/openssl.cnf
+
+cat <<EOF >> /etc/ssl/openssl.cnf
+[default_conf]
+ssl_conf = ssl_sect
+
+[ssl_sect]
+system_default = system_default_sect
+
+[system_default_sect]
+CipherString = DEFAULT@SECLEVEL=1
+MinProtocol = TLSv1
+EOF

--- a/subset/security/enable_tls1.sh
+++ b/subset/security/enable_tls1.sh
@@ -1,7 +1,8 @@
 #!/bin/bash 
 #
 
-sed -i '1s/^/openssl_conf = default_conf;\n/' /etc/ssl/openssl.cnf
+# Enable TLSv1 in OpenSSL
+sed -i '1s/^/openssl_conf = default_conf\n/' /etc/ssl/openssl.cnf
 
 cat <<EOF >> /etc/ssl/openssl.cnf
 [default_conf]
@@ -14,3 +15,10 @@ system_default = system_default_sect
 CipherString = DEFAULT@SECLEVEL=1
 MinProtocol = TLSv1
 EOF
+
+#Enable TLSv1 in JDK
+DISABLED_ALGORITHMS='jdk.tls.disabledAlgorithms=SSLv3, RC4, DES, MD5withRSA, \\
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \\
+    include jdk.disabled.namedCurves'
+
+perl -i -0777 -pe "s/^(jdk.tls.disabledAlgorithms=.*?(?!\\\n)\n)$/$DISABLED_ALGORITHMS/gms"  /etc/java-11-openjdk/security/java.security

--- a/testing/test_aux.out
+++ b/testing/test_aux.out
@@ -21,6 +21,21 @@ RESULT pass protocol.bacext.version Protocol version: 1
 RESULT skip protocol.bacext.pic BACnet device found, but pics.csv not found in device type directory.
 RESULT pass protocol.bacext.version Protocol version: 1
 RESULT pass protocol.bacext.pic The devices matches the PICS
+RESULT skip security.tls.v1_2_client No client initiated TLS communication detected
+RESULT skip security.tls.v1_2_server IOException unable to connect to server.
+RESULT skip security.tls.v1_3_client No client initiated TLS communication detected
+RESULT skip security.tls.v1_3_server IOException unable to connect to server.
+RESULT skip security.tls.v1_server IOException unable to connect to server.
+RESULT fail security.tls.v1_2_client Server Certificates Could not be validated.
+RESULT fail security.tls.v1_2_server Certificate is expired. Certificate has not been signed by a CA.
+RESULT pass security.tls.v1_3_client Client/Server completed handshake.
+RESULT fail security.tls.v1_3_server Certificate is expired. Certificate has not been signed by a CA.
+RESULT fail security.tls.v1_server Certificate is expired. Certificate has not been signed by a CA.
+RESULT pass security.tls.v1_2_client Client/Server completed handshake. ECDH/ECDSA supported ciphers. Server Certificates Valid.
+RESULT fail security.tls.v1_2_server Certificate has not been signed by a CA. Cipher Valid.
+RESULT pass security.tls.v1_3_client Client/Server completed handshake.
+RESULT fail security.tls.v1_3_server Certificate has not been signed by a CA.
+RESULT fail security.tls.v1_server Certificate has not been signed by a CA. Cipher Valid.
 RESULT skip security.password.http Port 80 not open on target device.
 RESULT skip security.password.https Port 443 not open on target device.
 RESULT skip security.password.ssh Port 22 not open on target device.
@@ -162,7 +177,7 @@ port-01 module_config modules
   },
   "tls": {
     "ca_file": "CA_Faux.pem",
-    "enabled": false,
+    "enabled": true,
     "timeout_sec": 0
   },
   "typeconf": {
@@ -259,7 +274,7 @@ port-02 module_config modules
   },
   "tls": {
     "ca_file": "CA_Faux.pem",
-    "enabled": false,
+    "enabled": true,
     "timeout_sec": 0
   },
   "udmi": {

--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -148,8 +148,7 @@ done
 
 # Add the RESULT lines from all aux test report files.
 capture_test_results bacext
-# TODO: Capture TLS results once tests are enabled
-# capture_test_results tls
+capture_test_results tls
 capture_test_results password
 capture_test_results discover
 capture_test_results network

--- a/testing/test_modules.out
+++ b/testing/test_modules.out
@@ -1,5 +1,23 @@
 Running testing/test_modules.sh
 Base Tests
+Testing tls alt
+RESULT skip security.tls.v1_2_client No client initiated TLS communication detected
+RESULT skip security.tls.v1_2_server IOException unable to connect to server.
+RESULT skip security.tls.v1_3_client No client initiated TLS communication detected
+RESULT skip security.tls.v1_3_server IOException unable to connect to server.
+RESULT skip security.tls.v1_server IOException unable to connect to server.
+Testing tls alt tls
+RESULT skip security.tls.v1_2_client No client initiated TLS communication detected
+RESULT pass security.tls.v1_2_server Certificate public key length is >= 224. Certificate active for current date. Certificate has been signed by a CA. Cipher Valid.
+RESULT skip security.tls.v1_3_client No client initiated TLS communication detected
+RESULT pass security.tls.v1_3_server Certificate public key length is >= 224. Certificate active for current date. Certificate has been signed by a CA. Cipher check not required.
+RESULT pass security.tls.v1_server Certificate public key length is >= 224. Certificate active for current date. Certificate has been signed by a CA. Cipher Valid.
+Testing tls alt expiredtls
+RESULT skip security.tls.v1_2_client No client initiated TLS communication detected
+RESULT fail security.tls.v1_2_server Certificate is expired. Certificate has not been signed by a CA.
+RESULT skip security.tls.v1_3_client No client initiated TLS communication detected
+RESULT fail security.tls.v1_3_server Certificate is expired. Certificate has not been signed by a CA.
+RESULT fail security.tls.v1_server Certificate is expired. Certificate has not been signed by a CA.
 Testing ssh
 RESULT skip security.ssh.version Device is not running an SSH server
 Testing ssh ssh

--- a/testing/test_modules.sh
+++ b/testing/test_modules.sh
@@ -19,11 +19,10 @@ python3 daq/configurator.py --json \
     resources/test_site/site_config.json > $TLS_CONFIG_DIR/module_config.json
 
 TEST_LIST=/tmp/module_tests.txt
-# TODO: Enable TLS tests once fixed
-# tls alt
-# tls alt tls
-# tls alt expiredtls
 cat > $TEST_LIST <<EOF
+tls alt
+tls alt tls
+tls alt expiredtls
 ssh
 ssh ssh
 ssh sshv1


### PR DESCRIPTION
This PR reverts PR #854 and resolves the underlying issue.

The problem was JDK11.0.11 update disabled TLS1 by default (https://www.oracle.com/java/technologies/javase/11-0-11-relnotes.html) This PR includes a script `subset/security/enable_tls1.sh` to update  the configuration at container build. The TLS test container uses Ubuntu 20.04 and a newer version of OpenSSL which also default disables older/insecure protocols, so TLSv1 has also been enabled in OpenSSL.

This bug meant the test always skipped, regardless of whether the DUT was running TLSv1 and the result should have been a pass/fail. The faux device currently run an older version, so is okay for now.