### PR TITLE
Prevent missing lsb_release from stopping setup

### DIFF
--- a/bin/setup_daq
+++ b/bin/setup_daq
@@ -1,7 +1,15 @@
 #!/bin/bash -e
 
 uname -a
-lsb_release -a
+
+if ! command -v lsb_release &> /dev/null
+then
+    echo "Warning: Command 'lsb_release' was not found. Is the 'lsb-core' package installed?"
+else
+    lsb_release -a
+fi
+
+echo ""
 
 ROOT=$(dirname $0)/..
 cd $ROOT


### PR DESCRIPTION
When trying to run the installation script `bin/setup_daq`, it is possible to run into an error like:

```
user@host:~/code/faucetsdn-daq$ ./bin/setup_daq
Linux host 4.4.0-19041-Microsoft #488-Microsoft Mon Sep 01 13:43:00 PST 2020 x86_64 GNU/Linux
./bin/setup_daq: line 4: lsb_release: command not found
```

This occurs when the linux package `lsb-core` is not installed, since it's not guaranteed to be installed by default on all distributions. For example, debian running in the Windows Subsystem for Linux did not have it installed by default.

It appears that `lsb-core` ends up being installed later in the setup_daq process anyway, so this PR proposes that we just check for `lsb_release` and emit a warning if it isn't yet installed. This will prevent the setup script from exiting with an error that may be cryptic to some people.
