### PR TITLE
Fix flaky aux ci test after enhanced nmap test

### DIFF
--- a/testing/test_aux.sh
+++ b/testing/test_aux.sh
@@ -159,7 +159,7 @@ more inst/run-*/scans/ip_triggers.txt | cat
 dhcp_done=$(fgrep done inst/run-9a02571e8f01/scans/ip_triggers.txt | wc -l)
 dhcp_long=$(fgrep long inst/run-9a02571e8f01/scans/ip_triggers.txt | wc -l)
 echo dhcp requests $((dhcp_done > 1)) $((dhcp_done < 3)) \
-     $((dhcp_long >= 1)) $((dhcp_long < 5)) | tee -a $TEST_RESULTS
+     $((dhcp_long >= 1)) $((dhcp_long < 6)) | tee -a $TEST_RESULTS
 sort inst/result.log | tee -a $TEST_RESULTS
 
 # Show partial logs from each test


### PR DESCRIPTION
The enhanced nmap test results in slightly longer AUX test times. As the CI tests are slightly variables, on some runs, on some runs, this means there the faux device makes more DHCP requests. (e.g. 

This resolve that by upping the DHCP request threshold from 5 to 6

Example successful CI: https://github.com/faucetsdn/daq/runs/4537256530?check_suite_focus=true
Example failure CI: https://github.com/faucetsdn/daq/runs/4559129359?check_suite_focus=true