### PR TITLE
Fix Pics Statement Failing Unsupported Properties

### DIFF
--- a/docker/include/bacnet/bacnetFaux/src/main/resources/pics.csv
+++ b/docker/include/bacnet/bacnetFaux/src/main/resources/pics.csv
@@ -1,4 +1,5 @@
 Bacnet_Object_Type,Bacnet_Object_Property,Property_Datatype,Conformance_Code,Supported,
+Bacnet_Analogue_Input,Unsupported_Property,,R,FALSE,
 Bacnet_Analogue_Input,Object_Identifier,BACnetObjectIdentifier,R,TRUE,
 Bacnet_Analogue_Input,Object_Name,CharacterString,W,TRUE,
 Bacnet_Analogue_Input,Object_Type,BACnetObjectType,R,TRUE,

--- a/subset/bacnet/bacnetTests/src/main/java/helper/PicsValidator.java
+++ b/subset/bacnet/bacnetTests/src/main/java/helper/PicsValidator.java
@@ -45,7 +45,12 @@ public class PicsValidator {
       boolean bacnetObjectPropertyIsFound =
           Pattern.compile(Pattern.quote(bacnetObjectProperty), Pattern.CASE_INSENSITIVE)
               .matcher(properties).find();
-      if (!bacnetObjectPropertyIsFound
+      if (!supported.equals(Supported)){
+        writeToAppendix(formatProperty, bacnetObjectType, bacnetObjectProperty, conformanceCode,
+                "SKIPPED", verboseOutput);
+        setResult(true);
+      }
+      else if (!bacnetObjectPropertyIsFound
           && (conformanceCode.contains(read) || conformanceCode.equals(write)) && supported.equals(Supported)
           && !bacnetObjectProperty.equals("Property List")) {
         writeToAppendix(formatProperty, bacnetObjectType, bacnetObjectProperty, conformanceCode,

--- a/subset/bacnet/bacnetTests/src/main/java/helper/PicsValidator.java
+++ b/subset/bacnet/bacnetTests/src/main/java/helper/PicsValidator.java
@@ -24,7 +24,12 @@ public class PicsValidator {
     Set<String> mapKeySet = bacnetPointsMap.keySet();
     ArrayList<String> keys = getMapKeys(mapKeySet, bacnetObjectType);
 
-    if (keys.size() == 0 && (conformanceCode.contains(read) || conformanceCode.equals(write))
+    if (keys.size() == 0 && !supported.equals(Supported)){
+      writeToAppendix(formatProperty, bacnetObjectType, bacnetObjectProperty, conformanceCode,
+              "SKIPPED", verboseOutput);
+      setResult(true);
+    }
+    else if (keys.size() == 0 && (conformanceCode.contains(read) || conformanceCode.equals(write))
             && !bacnetObjectProperty.equals("Property List")) {
       writeToAppendix(formatProperty, bacnetObjectType, bacnetObjectProperty, conformanceCode,
               "FAILED", verboseOutput);

--- a/subset/bacnet/test_bacext
+++ b/subset/bacnet/test_bacext
@@ -19,7 +19,7 @@ broadcast_ip=${parts[3]}
 
 version_test_id="bacnet_VERSION"
 pics_test_id="bacnet_PICS"
-verbose_output="true"
+verbose_output="false"
 
 echo Scanning bacnet $broadcast_ip from $local_ip
 

--- a/subset/bacnet/test_bacext
+++ b/subset/bacnet/test_bacext
@@ -19,7 +19,7 @@ broadcast_ip=${parts[3]}
 
 version_test_id="bacnet_VERSION"
 pics_test_id="bacnet_PICS"
-verbose_output="false"
+verbose_output="true"
 
 echo Scanning bacnet $broadcast_ip from $local_ip
 


### PR DESCRIPTION
Corrects issue: https://github.com/faucetsdn/daq/issues/886

Properties indicated as not supported, will be shown as SKIPPED in the result.  The same will occur if an object is in the pics statement but is not in the device as long as all properties are marked false.

Tested against the most recent device that had this failure present itself to confirm both test builds and real world scenarios.  Image included to show how the report and pics statement handle these scenarios.

![image](https://user-images.githubusercontent.com/50999916/153962326-4461046e-a651-4b40-b968-f734c4d4785a.png)
